### PR TITLE
[codex] Add CLI-backed DeviceToken auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,14 @@ require 'winthrop-client-ruby'
 
 # Setup authorization
 WinthropClient.configure do |config|
-  # Configure API key authorization: ApiKey
-  config.api_key['Authorization'] = 'YOUR API KEY'
-  # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  # config.api_key_prefix['Authorization'] = 'Bearer'
-
-  # Configure OAuth2 access token for authorization: Oauth2
-  config.access_token = 'YOUR ACCESS TOKEN'
-  # Configure a proc to get access tokens in lieu of the static access_token configuration
-  config.access_token_getter = -> { 'YOUR TOKEN GETTER PROC' } 
+  # Human users should authenticate with the Winthrop CLI first:
+  #   winthrop login
+  #
+  # The client library asks the CLI for access tokens and never handles refresh
+  # tokens directly.
+  config.access_token_getter = proc {
+    WinthropClient::DeviceToken.access_token
+  }
 end
 
 api_instance = WinthropClient::DefaultApi.new
@@ -682,6 +681,17 @@ Class | Method | HTTP request | Description
 
 ## Documentation for Authorization
 
+Human users should install the Winthrop CLI and run `winthrop login` before using this client. Configure the Ruby client to fetch access tokens from the CLI:
+
+```ruby
+WinthropClient.configure do |config|
+  config.access_token_getter = proc {
+    WinthropClient::DeviceToken.access_token
+  }
+end
+```
+
+Service accounts should continue to use `WinthropClient::RefreshToken` / `client_credentials` flows. Client libraries should consume access tokens only; they should never handle refresh tokens directly.
 
 Authentication schemes defined for the API:
 ### ApiKey
@@ -698,4 +708,3 @@ Authentication schemes defined for the API:
 - **Flow**: application
 - **Authorization URL**: 
 - **Scopes**: N/A
-

--- a/lib/winthrop-client-ruby.rb
+++ b/lib/winthrop-client-ruby.rb
@@ -13,6 +13,7 @@ Generator version: 7.19.0
 # Common files
 require 'winthrop-client-ruby/api_client'
 require 'winthrop-client-ruby/api_error'
+require 'winthrop-client-ruby/device_token'
 require 'winthrop-client-ruby/api_model_base'
 require 'winthrop-client-ruby/version'
 require 'winthrop-client-ruby/configuration'

--- a/lib/winthrop-client-ruby/api_client.rb
+++ b/lib/winthrop-client-ruby/api_client.rb
@@ -52,6 +52,14 @@ module WinthropClient
       tempfile = nil
       (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
       response = request.run
+      if response.code == 401 && retry_authentication_with_device_token?(opts)
+        clear_device_token_cache
+        request = build_request(http_method, path, opts)
+        tempfile = nil
+        (download_file(request) { tempfile = _1 }) if opts[:return_type] == 'File'
+        response = request.run
+        fail authentication_error(response) if response.code == 401
+      end
 
       if @config.debugging
         @config.logger.debug "HTTP response body ~BEGIN~\n#{response.body}\n~END~\n"
@@ -301,6 +309,21 @@ module WinthropClient
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
       @config.base_url(opts[:operation]) + path
+    end
+
+    def clear_device_token_cache
+      WinthropClient::DeviceToken.clear_cache if WinthropClient.const_defined?(:DeviceToken)
+    end
+
+    def retry_authentication_with_device_token?(opts)
+      Array(opts[:auth_names]).include?('Oauth2') && !@config.access_token_getter.nil?
+    end
+
+    def authentication_error(response)
+      ApiError.new(:code => response.code,
+                   :message => 'Authentication failed',
+                   :response_headers => response.headers,
+                   :response_body => response.body)
     end
 
     # Update header and query params based on authentication settings.

--- a/lib/winthrop-client-ruby/device_token.rb
+++ b/lib/winthrop-client-ruby/device_token.rb
@@ -1,0 +1,97 @@
+require 'open3'
+require 'timeout'
+require 'winthrop-client-ruby/api_error'
+
+module WinthropClient
+  class DeviceToken
+    CLI_NOT_INSTALLED_MESSAGE = 'Winthrop CLI is not installed. Install it and run `winthrop login`.'.freeze
+    DEFAULT_EXECUTABLE = 'winthrop'.freeze
+    DEFAULT_TIMEOUT = 10
+
+    @token = nil
+    @scopes = nil
+    @executable = DEFAULT_EXECUTABLE
+    @timeout = DEFAULT_TIMEOUT
+
+    class << self
+      attr_accessor :executable, :timeout
+
+      def access_token(scopes = nil)
+        normalized_scopes = normalize_scopes(scopes)
+        if @token.nil? || normalized_scopes != @scopes
+          @scopes = normalized_scopes
+          @token = fetch_access_token(normalized_scopes)
+        end
+
+        @token
+      end
+
+      def refresh_access_token(scopes = nil)
+        clear_cache
+        access_token(scopes)
+      end
+
+      def clear_cache
+        @token = nil
+        @scopes = nil
+      end
+
+      private
+
+        def fetch_access_token(scopes)
+          stdout, stderr, status = execute_cli(command_args(scopes))
+          unless status.success?
+            message = stderr.to_s.strip
+            message = 'Failed to retrieve access token from Winthrop CLI' if message.empty?
+            fail ApiError.new(message)
+          end
+
+          token = stdout.to_s.strip
+          fail ApiError.new('Winthrop CLI returned a blank access token') if token.empty?
+
+          token
+        rescue Errno::ENOENT
+          fail ApiError.new(CLI_NOT_INSTALLED_MESSAGE)
+        rescue Timeout::Error
+          fail ApiError.new('Timed out retrieving access token from Winthrop CLI')
+        end
+
+        def execute_cli(args)
+          stdout = +''
+          stderr = +''
+          status = nil
+
+          Open3.popen3(*args) do |stdin, out, err, wait_thr|
+            stdin.close
+            unless wait_thr.join(timeout)
+              Process.kill('TERM', wait_thr.pid)
+              fail Timeout::Error
+            end
+
+            stdout = out.read
+            stderr = err.read
+            status = wait_thr.value
+          end
+
+          [stdout, stderr, status]
+        end
+
+        def command_args(scopes)
+          args = [executable || DEFAULT_EXECUTABLE, 'token']
+          args += ['--scope', scopes.join(' ')] unless scopes.empty?
+          args
+        end
+
+        def normalize_scopes(scopes)
+          case scopes
+          when String
+            scopes.split
+          when Array
+            scopes.map { |scope| scope.to_s.strip }.reject(&:empty?)
+          else
+            []
+          end.sort
+        end
+    end
+  end
+end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -89,6 +89,80 @@ describe WinthropClient::ApiClient do
     end
   end
 
+  describe '#call_api authentication retry' do
+    let(:config) { WinthropClient::Configuration.new }
+    let(:api_client) { WinthropClient::ApiClient.new(config) }
+    let(:unauthorized_response) do
+      double(
+        'unauthorized_response',
+        code: 401,
+        success?: false,
+        timed_out?: false,
+        headers: {},
+        body: 'unauthorized',
+        status_message: 'Unauthorized'
+      )
+    end
+    let(:success_response) do
+      double(
+        'success_response',
+        code: 200,
+        success?: true,
+        timed_out?: false,
+        headers: {},
+        body: '',
+        status_message: 'OK'
+      )
+    end
+
+    it 'clears the DeviceToken cache, rebuilds auth headers, and retries once after a 401' do
+      tokens = ['old-access-token', 'new-access-token']
+      headers = []
+      config.access_token_getter = proc { tokens.shift }
+
+      request1 = double('request1', run: unauthorized_response)
+      request2 = double('request2', run: success_response)
+      allow(WinthropClient::DeviceToken).to receive(:clear_cache)
+      allow(Typhoeus::Request).to receive(:new) do |_url, opts|
+        headers << opts[:headers]['Authorization']
+        headers.length == 1 ? request1 : request2
+      end
+
+      data, code, _response_headers = api_client.call_api(:get, '/test', auth_names: ['Oauth2'])
+
+      expect(data).to be_nil
+      expect(code).to eq(200)
+      expect(headers).to eq(['Bearer old-access-token', 'Bearer new-access-token'])
+      expect(WinthropClient::DeviceToken).to have_received(:clear_cache).once
+      expect(Typhoeus::Request).to have_received(:new).twice
+    end
+
+    it 'raises an authentication error when the retry is also a 401' do
+      config.access_token_getter = proc { 'access-token' }
+      request1 = double('request1', run: unauthorized_response)
+      request2 = double('request2', run: unauthorized_response)
+      allow(WinthropClient::DeviceToken).to receive(:clear_cache)
+      allow(Typhoeus::Request).to receive(:new).and_return(request1, request2)
+
+      expect {
+        api_client.call_api(:get, '/test', auth_names: ['Oauth2'])
+      }.to raise_error(WinthropClient::ApiError, /Authentication failed/)
+      expect(Typhoeus::Request).to have_received(:new).twice
+    end
+
+    it 'does not retry static OAuth access tokens' do
+      config.access_token = 'static-token'
+      request = double('request', run: unauthorized_response)
+      allow(WinthropClient::DeviceToken).to receive(:clear_cache)
+      allow(Typhoeus::Request).to receive(:new).and_return(request)
+
+      expect {
+        api_client.call_api(:get, '/test', auth_names: ['Oauth2'])
+      }.to raise_error(WinthropClient::ApiError)
+      expect(Typhoeus::Request).to have_received(:new).once
+      expect(WinthropClient::DeviceToken).not_to have_received(:clear_cache)
+    end
+  end
 
 
   describe '#deserialize' do

--- a/spec/device_token_spec.rb
+++ b/spec/device_token_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+require 'winthrop-client-ruby/device_token'
+
+describe WinthropClient::DeviceToken do
+  let(:success_status) { double('status', success?: true) }
+  let(:failure_status) { double('status', success?: false) }
+
+  before do
+    described_class.executable = described_class::DEFAULT_EXECUTABLE
+    described_class.timeout = described_class::DEFAULT_TIMEOUT
+    described_class.clear_cache
+  end
+
+  describe '.access_token' do
+    it 'returns and caches the CLI token' do
+      expect(described_class).to receive(:execute_cli).once.
+        with(['winthrop', 'token']).
+        and_return(["access-token\n", '', success_status])
+
+      expect(described_class.access_token).to eq('access-token')
+      expect(described_class.access_token).to eq('access-token')
+    end
+
+    it 'uses configured executable and scopes' do
+      described_class.executable = '/usr/local/bin/winthrop'
+
+      expect(described_class).to receive(:execute_cli).
+        with(['/usr/local/bin/winthrop', 'token', '--scope', 'read write']).
+        and_return(["scoped-token\n", '', success_status])
+
+      expect(described_class.access_token(['write', 'read'])).to eq('scoped-token')
+    end
+
+    it 'raises a helpful authentication error when the CLI is missing' do
+      allow(described_class).to receive(:execute_cli).and_raise(Errno::ENOENT)
+
+      expect { described_class.access_token }.to raise_error(
+        WinthropClient::ApiError,
+        described_class::CLI_NOT_INSTALLED_MESSAGE
+      )
+    end
+
+    it 'surfaces stderr from non-zero CLI exits' do
+      allow(described_class).to receive(:execute_cli).
+        and_return(['', "please run winthrop login\n", failure_status])
+
+      expect { described_class.access_token }.to raise_error(WinthropClient::ApiError, 'please run winthrop login')
+    end
+
+    it 'raises an authentication error for blank stdout' do
+      allow(described_class).to receive(:execute_cli).and_return([" \n", '', success_status])
+
+      expect { described_class.access_token }.to raise_error(
+        WinthropClient::ApiError,
+        'Winthrop CLI returned a blank access token'
+      )
+    end
+
+    it 'raises an authentication error when CLI execution times out' do
+      allow(described_class).to receive(:execute_cli).and_raise(Timeout::Error)
+
+      expect { described_class.access_token }.to raise_error(
+        WinthropClient::ApiError,
+        'Timed out retrieving access token from Winthrop CLI'
+      )
+    end
+  end
+
+  describe '.refresh_access_token' do
+    it 'clears the cache and fetches a new token' do
+      allow(described_class).to receive(:execute_cli).
+        and_return(["old-token\n", '', success_status], ["new-token\n", '', success_status])
+
+      expect(described_class.access_token).to eq('old-token')
+      expect(described_class.refresh_access_token).to eq('new-token')
+    end
+  end
+
+  describe '.clear_cache' do
+    it 'causes the next access_token call to execute the CLI again' do
+      allow(described_class).to receive(:execute_cli).
+        and_return(["old-token\n", '', success_status], ["new-token\n", '', success_status])
+
+      expect(described_class.access_token).to eq('old-token')
+      described_class.clear_cache
+      expect(described_class.access_token).to eq('new-token')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Winthrop CLI-backed DeviceToken provider for human-user auth
- add in-memory token caching and one-shot 401 refresh/retry behavior
- document winthrop login prerequisite and DeviceToken vs service-account guidance

## Validation
- PATH=/home/eric/.rbenv/versions/3.4.8/bin:/home/eric/.local/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games /home/eric/.rbenv/versions/3.4.8/bin/bundle exec rspec spec/device_token_spec.rb spec/api_client_spec.rb spec/refresh_token_spec.rb

## Notes
- Draft PR for review visibility.
- Follow-up needed before merge: move generated-file and README changes into the normal regeneration/patch workflow so they survive client regeneration.